### PR TITLE
Fix milestone import: use str.strip() instead of non-existing str.trim()

### DIFF
--- a/project.py
+++ b/project.py
@@ -76,7 +76,7 @@ class Project:
 
     def _append_item_to_project(self, item):
         # todo assignee
-        closed = str(item.statusCategory.get('id')) == self.doneStatusCategoryId
+        closed = str(item.status.get('id')) == self.doneStatusCategoryId
         closed_at = ''
         if closed:
             try:

--- a/project.py
+++ b/project.py
@@ -110,7 +110,7 @@ class Project:
         try:
             self._project['Milestones'][item.fixVersion.text] += 1
             # this prop will be deleted later:
-            self._project['Issues'][-1]['milestone_name'] = item.fixVersion.text.trim()
+            self._project['Issues'][-1]['milestone_name'] = item.fixVersion.text.strip()
         except AttributeError:
             pass
 


### PR DESCRIPTION
`item.fixVersion.text.trim()` ends up as `AttributeError`, so the milestone is not included in the issue